### PR TITLE
add options for min/max size of window config

### DIFF
--- a/src/glass.rs
+++ b/src/glass.rs
@@ -361,6 +361,16 @@ impl GlassContext {
             .with_inner_size(winit::dpi::LogicalSize::new(config.width, config.height))
             .with_title(config.title);
 
+        // Min size
+        if let Some(inner_size) = config.min_size {
+            window_builder = window_builder.with_min_inner_size(inner_size);
+        }
+
+        // Max size
+        if let Some(inner_size) = config.max_size {
+            window_builder = window_builder.with_max_inner_size(inner_size);
+        }
+
         window_builder = match &config.pos {
             WindowPos::Maximized => window_builder.with_maximized(true),
             WindowPos::FullScreen => {

--- a/src/window.rs
+++ b/src/window.rs
@@ -4,7 +4,7 @@ use wgpu::{
     TextureFormat,
 };
 use winit::{
-    dpi::{PhysicalPosition, PhysicalSize},
+    dpi::{LogicalSize, PhysicalPosition, PhysicalSize},
     monitor::MonitorHandle,
     window::{Fullscreen, Window},
 };
@@ -19,6 +19,8 @@ pub struct WindowConfig {
     pub pos: WindowPos,
     pub present_mode: PresentMode,
     pub alpha_mode: CompositeAlphaMode,
+    pub max_size: Option<LogicalSize<u32>>,
+    pub min_size: Option<LogicalSize<u32>>,
     pub exit_on_esc: bool,
 }
 
@@ -32,6 +34,8 @@ impl Default for WindowConfig {
             present_mode: PresentMode::AutoVsync,
             alpha_mode: CompositeAlphaMode::Auto,
             exit_on_esc: false,
+            max_size: None,
+            min_size: None,
         }
     }
 }


### PR DESCRIPTION
This allows for min/max size configuration from the `WindowConfig`. You can also configure the window min/max in the start function, but I thought having it directly configurable on launch would be beneficial.

Thought it would be easier to consolidate the `*-width` and `*-height` properties into a single instance variable, but I chose `LogicalSize` for easy use. This could also be a `(u32,u32)` or something similar. Let me know what you think!