### PR TITLE
Fix egui demo zoom

### DIFF
--- a/examples/egui_gui.rs
+++ b/examples/egui_gui.rs
@@ -129,12 +129,12 @@ fn render_egui(
     let FullOutput {
         shapes,
         textures_delta,
+        pixels_per_point,
         ..
     } = egui_ctx.run(raw_input, |egui_ctx| {
         // Ui content
         ui_app.ui(egui_ctx);
     });
-    let pixels_per_point = window.window().scale_factor() as f32;
     // creates triangles to paint
     let clipped_primitives = egui_ctx.tessellate(shapes, pixels_per_point);
 


### PR DESCRIPTION
Without this, zooming the egui demo (e.g. with command-+) gives:

```
thread 'main' panicked at /Users/e/.cargo/registry/src/github.com-1ecc6299db9ec823/egui-0.28.1/src/context.rs:2194:18:
tessellate called with a different pixels_per_point than the font atlas was created with. You should use egui::FullOutput::pixels_per_point when tessellating.
```